### PR TITLE
Handle `null` input in `EscapePath`

### DIFF
--- a/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/MergeTask.cs
+++ b/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/MergeTask.cs
@@ -510,7 +510,7 @@ namespace ILMerge.MsBuild.Task
 
         private string EscapePath(string path)
         {
-            return Regex.Replace(path, @"\\", @"\\");
+            return Regex.Replace(path ?? "", @"\\", @"\\");
         }
 
         #endregion


### PR DESCRIPTION
Don't fail with an exception, but just return an empty string.