### PR TITLE
include unmergedassemblies as searchdirectories

### DIFF
--- a/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/MergeTask.cs
+++ b/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/MergeTask.cs
@@ -53,7 +53,7 @@ namespace ILMerge.MsBuild.Task
 
         public virtual ITaskItem[] InputAssemblies { get; set; }
 
-        public string[] UnmergedAssemblies { get; set; }
+        public string[] AdditionalLocations { get; set; }
 
         [Required]
         public string ConfigurationFilePath { get; set; }
@@ -308,9 +308,9 @@ namespace ILMerge.MsBuild.Task
                 settings.Advanced.SearchDirectories.Add(this.TargetDir);
             }
 
-            if (this.UnmergedAssemblies != null && this.UnmergedAssemblies.Any())
+            if (this.AdditionalLocations != null && this.AdditionalLocations.Any())
             {
-                foreach (var dir in this.UnmergedAssemblies)
+                foreach (var dir in this.AdditionalLocations)
                 {
                     if (!settings.Advanced.SearchDirectories.Contains(dir))
                     {

--- a/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/MergeTask.cs
+++ b/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/MergeTask.cs
@@ -1,4 +1,5 @@
 ﻿#region MIT License
+
 /*
     MIT License
 
@@ -22,7 +23,8 @@
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
  */
-#endregion
+
+#endregion MIT License
 
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
@@ -38,20 +40,19 @@ using System.Threading.Tasks;
 
 namespace ILMerge.MsBuild.Task
 {
-
     // project properties
     // http://stackoverflow.com/questions/2772426/how-to-access-the-msbuild-s-properties-list-when-coding-a-custom-task
-
 
     // dependencies
     // http://stackoverflow.com/questions/8849289/get-dependent-assemblies
 
     public class MergeTask : Microsoft.Build.Utilities.Task
     {
-
         #region Public Properties
 
         public virtual ITaskItem[] InputAssemblies { get; set; }
+
+        public virtual string[] UnmergedAssemblies { get; set; }
 
         [Required]
         public string ConfigurationFilePath { get; set; }
@@ -82,7 +83,7 @@ namespace ILMerge.MsBuild.Task
 
         public string KeyFile { get; set; }
 
-        #endregion
+        #endregion Public Properties
 
         #region Constructors
 
@@ -91,13 +92,12 @@ namespace ILMerge.MsBuild.Task
             this.InputAssemblies = new ITaskItem[0];
         }
 
-        #endregion
+        #endregion Constructors
 
         #region Public Methods
 
         public override bool Execute()
         {
-
             LogInputVariables();
 
             string jsonConfig;
@@ -106,22 +106,24 @@ namespace ILMerge.MsBuild.Task
             var settings = new MergerSettings();
 
             // try to read configuration if file exists
-            if (!ReadConfigFile(out jsonConfig)) {
+            if (!ReadConfigFile(out jsonConfig))
+            {
                 return false;
             }
 
             // replace tokens if applicable
-            if(!string.IsNullOrWhiteSpace(jsonConfig))
+            if (!string.IsNullOrWhiteSpace(jsonConfig))
             {
                 jsonConfig = ReplaceTokens(jsonConfig);
-            }            
+            }
 
             // if json config exists, try to deserialize into settings object
-            if (!string.IsNullOrWhiteSpace(jsonConfig) && !DeserializeJsonConfig(jsonConfig, out settings)) {
+            if (!string.IsNullOrWhiteSpace(jsonConfig) && !DeserializeJsonConfig(jsonConfig, out settings))
+            {
                 return false;
             }
 
-            if(settings == null)
+            if (settings == null)
             {
                 // create instance if seetings still null which indicates a custom json config was not used
                 settings = new MergerSettings();
@@ -129,10 +131,10 @@ namespace ILMerge.MsBuild.Task
 
             // apply defaults
             SetDefaults(settings);
-            
-            if(settings.General.AlternativeILMergePath.HasValue())
+
+            if (settings.General.AlternativeILMergePath.HasValue())
             {
-                if(!File.Exists(settings.General.AlternativeILMergePath))
+                if (!File.Exists(settings.General.AlternativeILMergePath))
                 {
                     Log.LogError($"An alternative path for ILMerge.exe was provided but the file was not found: {settings.General.AlternativeILMergePath}");
                     return false;
@@ -148,10 +150,10 @@ namespace ILMerge.MsBuild.Task
                 exePath = this.GetILMergePath();
             }
 
-            if(!exePath.HasValue())
+            if (!exePath.HasValue())
             {
-                Log.LogError("ILMerge.exe was no located. Make sure you have the ILMerge nuget package installed. " 
-                    + "If you defined a custom packages folder in your Nuget.Config it is possible we are having a hard time figuring it out. " 
+                Log.LogError("ILMerge.exe was no located. Make sure you have the ILMerge nuget package installed. "
+                    + "If you defined a custom packages folder in your Nuget.Config it is possible we are having a hard time figuring it out. "
                     + "In this case please use attribute 'AlternativeILMergePath' in the configuration file to indicate the full path for ILMerge.exe.");
                 return false;
             }
@@ -164,18 +166,15 @@ namespace ILMerge.MsBuild.Task
                 return false;
             }
 
-
             return true;
-
         }
 
-        #endregion
+        #endregion Public Methods
 
         #region Private Methods
 
         private void LogInputVariables()
         {
-
             Log.LogMessage($"SolutionDir: {SolutionDir}");
             Log.LogMessage($"SolutionPath: {SolutionPath}");
             Log.LogMessage($"ProjectDir: {ProjectDir}");
@@ -188,16 +187,14 @@ namespace ILMerge.MsBuild.Task
             Log.LogMessage($"TargetArchitecture: {TargetArchitecture}");
             Log.LogMessage($"KeyFile: {KeyFile}");
             Log.LogMessage($"ConfigurationFilePath: {ConfigurationFilePath}");
-
         }
 
         private bool DeserializeJsonConfig(string jsonConfig, out MergerSettings settings)
         {
-
             settings = null;
             bool success = true;
 
-            if(string.IsNullOrWhiteSpace(jsonConfig))
+            if (string.IsNullOrWhiteSpace(jsonConfig))
             {
                 Log.LogError("Unable to deserialize configuration. Configuration string is null or empty.");
                 return false;
@@ -217,7 +214,6 @@ namespace ILMerge.MsBuild.Task
             }
 
             return success;
-
         }
 
         private string ReplaceTokens(string jsonConfig)
@@ -236,10 +232,9 @@ namespace ILMerge.MsBuild.Task
 
         private void SetDefaults(MergerSettings settings)
         {
-
             if (settings == null) throw new ArgumentNullException(nameof(settings));
 
-            if(settings.General == null)
+            if (settings.General == null)
             {
                 settings.General = new GeneralSettings();
             }
@@ -262,21 +257,20 @@ namespace ILMerge.MsBuild.Task
                 Log.LogMessage($"Applying default value for TargetPlatform: {settings.General.TargetPlatform}");
             }
 
-            if(settings.General.InputAssemblies == null || settings.General.InputAssemblies.Count == 0)
+            if (settings.General.InputAssemblies == null || settings.General.InputAssemblies.Count == 0)
             {
                 Log.LogMessage("No input assembles were found in configuration.");
 
                 settings.General.InputAssemblies = new List<string>();
 
                 Log.LogMessage($"Adding target assembly: {this.TargetPath}");
-                settings.General.InputAssemblies.Add(this.TargetPath);                
+                settings.General.InputAssemblies.Add(this.TargetPath);
 
                 foreach (var item in this.InputAssemblies)
                 {
                     Log.LogMessage($"Adding assembly: {item.ItemSpec}");
                     settings.General.InputAssemblies.Add(item.ItemSpec);
                 }
-
             }
             else
             {
@@ -286,7 +280,7 @@ namespace ILMerge.MsBuild.Task
                 }
 
                 Log.LogMessage($"Adding target assembly at position [0]: {this.TargetPath}");
-                settings.General.InputAssemblies.Insert(0, this.TargetPath);                
+                settings.General.InputAssemblies.Insert(0, this.TargetPath);
             }
 
             if (settings.Advanced == null)
@@ -294,22 +288,28 @@ namespace ILMerge.MsBuild.Task
                 settings.Advanced = new AdvancedSettings();
             }
 
-            if(settings.Advanced.SearchDirectories == null)
+            if (settings.Advanced.SearchDirectories == null)
             {
                 settings.Advanced.SearchDirectories = new List<string>();
             }
 
-            if(!settings.Advanced.SearchDirectories.Contains(this.TargetDir))
+            if (!settings.Advanced.SearchDirectories.Contains(this.TargetDir))
             {
                 settings.Advanced.SearchDirectories.Add(this.TargetDir);
             }
 
-            
+            if (this.UnmergedAssemblies != null && this.UnmergedAssemblies.Any())
+            {
+                foreach (var fullpath in this.UnmergedAssemblies)
+                {
+                    var dir = Path.GetDirectoryName(fullpath);
+                    settings.Advanced.SearchDirectories.Add(dir);
+                }
+            }
         }
 
         private bool MergeAssemblies(string mergerPath, MergerSettings settings)
         {
-
             bool success = true;
             Assembly ilmerge = LoadILMerge(mergerPath);
             Type ilmergeType = ilmerge.GetType("ILMerging.ILMerge", true, true);
@@ -337,18 +337,17 @@ namespace ILMerge.MsBuild.Task
             merger.UnionMerge = settings.Advanced.UnionMerge;
             merger.XmlDocumentation = settings.Advanced.XmlDocumentation;
 
-            if(!string.IsNullOrWhiteSpace(settings.Advanced.ExcludeFile))
+            if (!string.IsNullOrWhiteSpace(settings.Advanced.ExcludeFile))
                 merger.ExcludeFile = settings.Advanced.ExcludeFile;
 
             merger.Internalize = settings.Advanced.Internalize;
-            
+
             if (settings.Advanced.TargetKind.HasValue())
-                merger.TargetKind = (dynamic) Enum.Parse(merger.TargetKind.GetType(), settings.Advanced.TargetKind);
+                merger.TargetKind = (dynamic)Enum.Parse(merger.TargetKind.GetType(), settings.Advanced.TargetKind);
 
             if (settings.Advanced.Version.HasValue())
             {
                 merger.Version = new Version(settings.Advanced.Version);
-
             }
 
             if (settings.Advanced.AllowDuplicateType.HasValue())
@@ -366,7 +365,7 @@ namespace ILMerge.MsBuild.Task
                 }
             }
 
-            string[] tp = settings.General.TargetPlatform.Split(new string[] {","}, StringSplitOptions.RemoveEmptyEntries);
+            string[] tp = settings.General.TargetPlatform.Split(new string[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
             merger.SetTargetPlatform(tp[0].Trim(), @tp[1].Trim());
             merger.SetInputAssemblies(settings.General.InputAssemblies.ToArray());
@@ -374,7 +373,6 @@ namespace ILMerge.MsBuild.Task
 
             try
             {
-
                 string outputDir = Path.GetDirectoryName(settings.General.OutputFile);
                 if (!Directory.Exists(outputDir))
                 {
@@ -407,12 +405,10 @@ namespace ILMerge.MsBuild.Task
             }
 
             return success;
-
         }
 
         private Assembly LoadILMerge(string mergerPath)
         {
-
             if (string.IsNullOrWhiteSpace(mergerPath)) throw new ArgumentNullException(nameof(mergerPath));
 
             Log.LogMessage($"Loading ILMerge from '{mergerPath}'.");
@@ -420,12 +416,10 @@ namespace ILMerge.MsBuild.Task
             Assembly ilmerge = Assembly.LoadFrom(mergerPath);
 
             return ilmerge;
-
         }
 
         private bool ReadConfigFile(out string jsonConfig)
         {
-
             jsonConfig = string.Empty;
             bool success = true;
 
@@ -443,11 +437,9 @@ namespace ILMerge.MsBuild.Task
                 {
                     try
                     {
-
                         Log.LogMessage($"Loading configuration from: {ConfigurationFilePath}");
                         jsonConfig = File.ReadAllText(ConfigurationFilePath, Encoding.UTF8);
                         Log.LogMessage($"Configuration file loaded successfully.");
-                                                
                     }
                     catch (Exception ex)
                     {
@@ -459,12 +451,10 @@ namespace ILMerge.MsBuild.Task
             }
 
             return success;
-
         }
 
         public string GetILMergePath()
         {
-
             string exePath = null;
             string errMsg;
             var failedPaths = new List<string>();
@@ -483,7 +473,7 @@ namespace ILMerge.MsBuild.Task
             }
 
             // look at target dir;
-            if(!string.IsNullOrWhiteSpace(TargetDir))
+            if (!string.IsNullOrWhiteSpace(TargetDir))
             {
                 if (ExeLocationHelper.TryValidateILMergePath(this.TargetDir, out exePath))
                 {
@@ -499,7 +489,7 @@ namespace ILMerge.MsBuild.Task
             }
 
             // look for "packages" folder at the solution root and if one is found, look for ILMerge package folder
-            if(!string.IsNullOrWhiteSpace(this.SolutionDir))
+            if (!string.IsNullOrWhiteSpace(this.SolutionDir))
             {
                 if (ExeLocationHelper.TryILMergeInSolutionDir(this.SolutionDir, out exePath))
                 {
@@ -521,40 +511,34 @@ namespace ILMerge.MsBuild.Task
                 return exePath;
             }
             {
-
                 foreach (var err in failedPaths)
                 {
                     Log.LogWarning(err);
                 }
 
                 Log.LogWarning($"Unable to determine custom package location or, location was determined but an ILMerge package folder was not found.");
-
             }
 
             return exePath;
-
         }
 
         private string ToAbsolutePath(string relativePath)
         {
-
             // if path is not rooted assume it is relative.
             // convert relative to absolute using project dir as root.
 
             if (string.IsNullOrWhiteSpace(relativePath)) throw new ArgumentNullException(relativePath);
 
-            if(Path.IsPathRooted(relativePath))
+            if (Path.IsPathRooted(relativePath))
             {
                 return relativePath;
             }
 
             return Path.GetFullPath(Path.Combine(ProjectDir, relativePath));
-
         }
 
         private void LogConfigFile(MergerSettings settings)
         {
-
             string outputPath = Path.Combine(Path.GetDirectoryName(settings.General.OutputFile), Path.GetFileNameWithoutExtension(settings.General.OutputFile) + ".merge.json");
             string outputDir = Path.GetDirectoryName(outputPath);
 
@@ -572,7 +556,6 @@ namespace ILMerge.MsBuild.Task
             return Regex.Replace(path ?? "", @"\\", @"\\");
         }
 
-        #endregion
-
+        #endregion Private Methods
     }
 }

--- a/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/MergeTask.cs
+++ b/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/MergeTask.cs
@@ -1,5 +1,4 @@
 ﻿#region MIT License
-
 /*
     MIT License
 
@@ -23,8 +22,7 @@
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
  */
-
-#endregion MIT License
+#endregion
 
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
@@ -40,19 +38,22 @@ using System.Threading.Tasks;
 
 namespace ILMerge.MsBuild.Task
 {
+
     // project properties
     // http://stackoverflow.com/questions/2772426/how-to-access-the-msbuild-s-properties-list-when-coding-a-custom-task
+
 
     // dependencies
     // http://stackoverflow.com/questions/8849289/get-dependent-assemblies
 
     public class MergeTask : Microsoft.Build.Utilities.Task
     {
+
         #region Public Properties
 
         public virtual ITaskItem[] InputAssemblies { get; set; }
 
-        public virtual string[] UnmergedAssemblies { get; set; }
+        public string[] UnmergedAssemblies { get; set; }
 
         [Required]
         public string ConfigurationFilePath { get; set; }
@@ -83,7 +84,7 @@ namespace ILMerge.MsBuild.Task
 
         public string KeyFile { get; set; }
 
-        #endregion Public Properties
+        #endregion
 
         #region Constructors
 
@@ -92,12 +93,13 @@ namespace ILMerge.MsBuild.Task
             this.InputAssemblies = new ITaskItem[0];
         }
 
-        #endregion Constructors
+        #endregion
 
         #region Public Methods
 
         public override bool Execute()
         {
+
             LogInputVariables();
 
             string jsonConfig;
@@ -166,15 +168,18 @@ namespace ILMerge.MsBuild.Task
                 return false;
             }
 
+
             return true;
+
         }
 
-        #endregion Public Methods
+        #endregion
 
         #region Private Methods
 
         private void LogInputVariables()
         {
+
             Log.LogMessage($"SolutionDir: {SolutionDir}");
             Log.LogMessage($"SolutionPath: {SolutionPath}");
             Log.LogMessage($"ProjectDir: {ProjectDir}");
@@ -187,10 +192,12 @@ namespace ILMerge.MsBuild.Task
             Log.LogMessage($"TargetArchitecture: {TargetArchitecture}");
             Log.LogMessage($"KeyFile: {KeyFile}");
             Log.LogMessage($"ConfigurationFilePath: {ConfigurationFilePath}");
+
         }
 
         private bool DeserializeJsonConfig(string jsonConfig, out MergerSettings settings)
         {
+
             settings = null;
             bool success = true;
 
@@ -214,6 +221,7 @@ namespace ILMerge.MsBuild.Task
             }
 
             return success;
+
         }
 
         private string ReplaceTokens(string jsonConfig)
@@ -232,6 +240,7 @@ namespace ILMerge.MsBuild.Task
 
         private void SetDefaults(MergerSettings settings)
         {
+
             if (settings == null) throw new ArgumentNullException(nameof(settings));
 
             if (settings.General == null)
@@ -271,6 +280,7 @@ namespace ILMerge.MsBuild.Task
                     Log.LogMessage($"Adding assembly: {item.ItemSpec}");
                     settings.General.InputAssemblies.Add(item.ItemSpec);
                 }
+
             }
             else
             {
@@ -310,6 +320,7 @@ namespace ILMerge.MsBuild.Task
 
         private bool MergeAssemblies(string mergerPath, MergerSettings settings)
         {
+
             bool success = true;
             Assembly ilmerge = LoadILMerge(mergerPath);
             Type ilmergeType = ilmerge.GetType("ILMerging.ILMerge", true, true);
@@ -348,6 +359,7 @@ namespace ILMerge.MsBuild.Task
             if (settings.Advanced.Version.HasValue())
             {
                 merger.Version = new Version(settings.Advanced.Version);
+
             }
 
             if (settings.Advanced.AllowDuplicateType.HasValue())
@@ -373,6 +385,7 @@ namespace ILMerge.MsBuild.Task
 
             try
             {
+
                 string outputDir = Path.GetDirectoryName(settings.General.OutputFile);
                 if (!Directory.Exists(outputDir))
                 {
@@ -405,10 +418,12 @@ namespace ILMerge.MsBuild.Task
             }
 
             return success;
+
         }
 
         private Assembly LoadILMerge(string mergerPath)
         {
+
             if (string.IsNullOrWhiteSpace(mergerPath)) throw new ArgumentNullException(nameof(mergerPath));
 
             Log.LogMessage($"Loading ILMerge from '{mergerPath}'.");
@@ -416,10 +431,12 @@ namespace ILMerge.MsBuild.Task
             Assembly ilmerge = Assembly.LoadFrom(mergerPath);
 
             return ilmerge;
+
         }
 
         private bool ReadConfigFile(out string jsonConfig)
         {
+
             jsonConfig = string.Empty;
             bool success = true;
 
@@ -437,9 +454,11 @@ namespace ILMerge.MsBuild.Task
                 {
                     try
                     {
+
                         Log.LogMessage($"Loading configuration from: {ConfigurationFilePath}");
                         jsonConfig = File.ReadAllText(ConfigurationFilePath, Encoding.UTF8);
                         Log.LogMessage($"Configuration file loaded successfully.");
+
                     }
                     catch (Exception ex)
                     {
@@ -451,10 +470,12 @@ namespace ILMerge.MsBuild.Task
             }
 
             return success;
+
         }
 
         public string GetILMergePath()
         {
+
             string exePath = null;
             string errMsg;
             var failedPaths = new List<string>();
@@ -511,19 +532,23 @@ namespace ILMerge.MsBuild.Task
                 return exePath;
             }
             {
+
                 foreach (var err in failedPaths)
                 {
                     Log.LogWarning(err);
                 }
 
                 Log.LogWarning($"Unable to determine custom package location or, location was determined but an ILMerge package folder was not found.");
+
             }
 
             return exePath;
+
         }
 
         private string ToAbsolutePath(string relativePath)
         {
+
             // if path is not rooted assume it is relative.
             // convert relative to absolute using project dir as root.
 
@@ -535,10 +560,12 @@ namespace ILMerge.MsBuild.Task
             }
 
             return Path.GetFullPath(Path.Combine(ProjectDir, relativePath));
+
         }
 
         private void LogConfigFile(MergerSettings settings)
         {
+
             string outputPath = Path.Combine(Path.GetDirectoryName(settings.General.OutputFile), Path.GetFileNameWithoutExtension(settings.General.OutputFile) + ".merge.json");
             string outputDir = Path.GetDirectoryName(outputPath);
 
@@ -556,6 +583,9 @@ namespace ILMerge.MsBuild.Task
             return Regex.Replace(path ?? "", @"\\", @"\\");
         }
 
-        #endregion Private Methods
+        #endregion
+
     }
 }
+
+

--- a/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/MergeTask.cs
+++ b/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/MergeTask.cs
@@ -312,7 +312,10 @@ namespace ILMerge.MsBuild.Task
             {
                 foreach (var dir in this.UnmergedAssemblies)
                 {
-                    settings.Advanced.SearchDirectories.Add(dir);
+                    if (!settings.Advanced.SearchDirectories.Contains(dir))
+                    {
+                        settings.Advanced.SearchDirectories.Add(dir);
+                    }
                 }
             }
         }

--- a/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/MergeTask.cs
+++ b/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/MergeTask.cs
@@ -310,9 +310,8 @@ namespace ILMerge.MsBuild.Task
 
             if (this.UnmergedAssemblies != null && this.UnmergedAssemblies.Any())
             {
-                foreach (var fullpath in this.UnmergedAssemblies)
+                foreach (var dir in this.UnmergedAssemblies)
                 {
-                    var dir = Path.GetDirectoryName(fullpath);
                     settings.Advanced.SearchDirectories.Add(dir);
                 }
             }

--- a/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/MergerSettings.cs
+++ b/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/MergerSettings.cs
@@ -47,6 +47,12 @@ namespace ILMerge.MsBuild.Task
         public string ToJson()
         {
             var srl = new JavaScriptSerializer();
+
+            if(this.Advanced != null && this.Advanced.SearchDirectories != null)
+            {
+                this.Advanced.SearchDirectories = this.Advanced.SearchDirectories.OrderBy(d => d).ToList();
+            }
+            
             var json = srl.Serialize(this);
             return json;
         }

--- a/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/build/ILMerge.MSBuild.Task.targets
+++ b/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/build/ILMerge.MSBuild.Task.targets
@@ -6,8 +6,8 @@
   <Target Name="MergeAssembly" AfterTargets="CopyFilesToOutputDirectory">
 
     <ItemGroup>
-      <CopyLocalReferences Include="@(ReferencePath)" Condition=" '%(CopyLocal)' == 'true' " />
-      <UnmergedAssemblies Include="@(ReferencePath)" Condition=" '%(CopyLocal)' == 'false' " />
+      <CopyLocalReferences Include="@(ReferencePath)" Condition=" '%(CopyLocal)' == 'true' "/>
+     <UnmergedAssemblies Include="@(ReferencePath)" Condition=" '%(CopyLocal)' == 'false' " />
     </ItemGroup>
 
     <MergeTask
@@ -24,6 +24,9 @@
       TargetFrameworkVersion="$(TargetFrameworkVersion)"
       TargetArchitecture="$(Platform)"
       KeyFile="$(AssemblyOriginatorKeyFile)"
-      ConfigurationFilePath="$(ProjectDir)ILMergeConfig.json" />
+      ConfigurationFilePath="$(ProjectDir)ILMergeConfig.json"
+      />
+
   </Target>
+
 </Project>

--- a/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/build/ILMerge.MSBuild.Task.targets
+++ b/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/build/ILMerge.MSBuild.Task.targets
@@ -6,7 +6,8 @@
   <Target Name="MergeAssembly" AfterTargets="CopyFilesToOutputDirectory">
 
     <ItemGroup>
-      <CopyLocalReferences Include="@(ReferencePath)" Condition=" '%(CopyLocal)' == 'true' "/>
+      <CopyLocalReferences Include="@(ReferencePath)" Condition=" '%(CopyLocal)' == 'true' " />
+      <UnmergedAssemblies Include="@(ReferencePath)" Condition=" '%(CopyLocal)' == 'false' " />
     </ItemGroup>
 
     <MergeTask
@@ -19,12 +20,10 @@
       TargetPath="$(TargetPath)"
       TargetFileName="$(TargetFileName)"
       InputAssemblies="@(CopyLocalReferences)"
+      UnmergedAssemblies="@(UnmergedAssemblies->'%(FullPath)')"
       TargetFrameworkVersion="$(TargetFrameworkVersion)"
       TargetArchitecture="$(Platform)"
       KeyFile="$(AssemblyOriginatorKeyFile)"
-      ConfigurationFilePath="$(ProjectDir)ILMergeConfig.json"
-      />
-
+      ConfigurationFilePath="$(ProjectDir)ILMergeConfig.json" />
   </Target>
-
 </Project>

--- a/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/build/ILMerge.MSBuild.Task.targets
+++ b/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/build/ILMerge.MSBuild.Task.targets
@@ -7,7 +7,7 @@
 
     <ItemGroup>
       <CopyLocalReferences Include="@(ReferencePath)" Condition=" '%(CopyLocal)' == 'true' "/>
-     <UnmergedAssemblies Include="@(ReferencePath)" Condition=" '%(CopyLocal)' == 'false' " />
+      <UnmergedAssemblies Include="@(ReferencePath)" Condition=" '%(CopyLocal)' == 'false' " />
     </ItemGroup>
 
     <MergeTask
@@ -20,7 +20,7 @@
       TargetPath="$(TargetPath)"
       TargetFileName="$(TargetFileName)"
       InputAssemblies="@(CopyLocalReferences)"
-      UnmergedAssemblies="@(UnmergedAssemblies->'%(FullPath)')"
+      UnmergedAssemblies="@(UnmergedAssemblies->'%(rootdir)%(directory)')"
       TargetFrameworkVersion="$(TargetFrameworkVersion)"
       TargetArchitecture="$(Platform)"
       KeyFile="$(AssemblyOriginatorKeyFile)"

--- a/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/build/ILMerge.MSBuild.Task.targets
+++ b/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/build/ILMerge.MSBuild.Task.targets
@@ -7,7 +7,7 @@
 
     <ItemGroup>
       <CopyLocalReferences Include="@(ReferencePath)" Condition=" '%(CopyLocal)' == 'true' "/>
-      <UnmergedAssemblies Include="@(ReferencePath)" Condition=" '%(CopyLocal)' == 'false' " />
+      <DoNotCopyReferences Include="@(ReferencePath)" Condition=" '%(CopyLocal)' == 'false' " />
     </ItemGroup>
 
     <MergeTask
@@ -20,7 +20,7 @@
       TargetPath="$(TargetPath)"
       TargetFileName="$(TargetFileName)"
       InputAssemblies="@(CopyLocalReferences)"
-      UnmergedAssemblies="@(UnmergedAssemblies->'%(rootdir)%(directory)')"
+      AdditionalLocations="@(DoNotCopyReferences->'%(rootdir)%(directory)')"
       TargetFrameworkVersion="$(TargetFrameworkVersion)"
       TargetArchitecture="$(Platform)"
       KeyFile="$(AssemblyOriginatorKeyFile)"


### PR DESCRIPTION
When merging dll's for a CRM plugin assembly, you don't want to merge the CRM SDK dll's since this will throw errors when registrating.
To fix this you should set the 'Copy Local' to false for the CRM SDK dll's but this will result in ILMerge to throw an unresolved reference error.

Adding unmerged assemblies (or references with 'Copy Local' set to false) as search directories will allow ILMerge to find the reference.