### PR TITLE
Support .NET Framework v4.8

### DIFF
--- a/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/FrameworkInfo.cs
+++ b/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/FrameworkInfo.cs
@@ -73,6 +73,7 @@ namespace ILMerge.MsBuild.Task
                 case "45":
                 case "46":
                 case "47":
+                case "48":
                     frameworkVersion = TargetDotNetFrameworkVersion.Version45;
                     return true;
             }


### PR DESCRIPTION
I know this is trivial but wanted to submit this PR regardless to be of a little more help than submitting an issue. It seems v4.8 is still classified under `TargetDotNetFrameworkVersion.Version45`.