### PR TITLE
Added advanced property "DeleteCopiesOverwriteTarget". If true will d…

### DIFF
--- a/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/AdvancedSettings.cs
+++ b/ILMerge.MSBuild.Task/ILMerge.MSBuild.Task/AdvancedSettings.cs
@@ -46,7 +46,7 @@ namespace ILMerge.MsBuild.Task
         public bool AllowZeroPeKind { get; set; } = false;
 
         public string AttributeFile { get; set; } = null;
-
+        
         public bool Closed { get; set; } = false;
 
         public bool CopyAttributes { get; set; } = true;
@@ -54,6 +54,8 @@ namespace ILMerge.MsBuild.Task
         public bool DebugInfo { get; set; } = true;
 
         public bool DelaySign { get; set; } = false;
+
+        public bool DeleteCopiesOverwriteTarget { get; set; } = false;
 
         public string ExcludeFile { get; set; } = "";
 


### PR DESCRIPTION
Attempt at addressing issue #15. Unfortunately I couldn't re-open that issue, but see my comment there for more information and background.

Added advanced property "DeleteCopiesOverwriteTarget". If true will delete any CopyTo assemblies in the TargetDir and then overwrite the TargetFile with the merged one from OutputFile. 